### PR TITLE
update SpecAcqBaseMonitor

### DIFF
--- a/cosmo/monitors/acq_monitors.py
+++ b/cosmo/monitors/acq_monitors.py
@@ -454,7 +454,7 @@ class SpecAcqBaseMonitor(BaseMonitor):
         fgs_groups, std_results = self.results  # groups are stored in the results attribute since track returns them.
 
         trace_count = {'F1': 0, 'F2': 0, 'F3': 0}
-        lp_colors = ['#1f77b4', '#2ca02c', '#8c564b', '#bcbd22']  # blue, green, brown, yellow-green
+        lp_colors = ['#1f77b4', '#2ca02c', '#8c564b', '#bcbd22', '#8317bb', '#3ee0d8']  # blue, green, brown, yellow-green, purple, cyan
         detector_symbols = {'NUV': 'x', 'FUV': 'circle'}
         for name, group in fgs_groups:
             lp_groups = group.groupby('LIFE_ADJ')


### PR DESCRIPTION
added purple and cyan colors to the "lp_colors" list in the plot method to account for LP5 and LP6